### PR TITLE
fix: Disable bridge MAC learning in virt-prerunner

### DIFF
--- a/build/virt-prerunner/Dockerfile
+++ b/build/virt-prerunner/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go build -a cmd/virt-prerunn
 
 FROM alpine
 
-RUN apk add --no-cache tini curl screen dnsmasq cdrkit iptables
+RUN apk add --no-cache tini curl screen dnsmasq cdrkit iptables iproute2
 
 RUN set -eux; \
     mkdir /var/lib/cloud-hypervisor; \


### PR DESCRIPTION
fix #40