### PR TITLE
fix: Update CH openapi manifest URL

### DIFF
--- a/cmd/cloud-hypervisor-client-gen/main.go
+++ b/cmd/cloud-hypervisor-client-gen/main.go
@@ -18,7 +18,8 @@ import (
 var clientTemplate string
 
 func main() {
-	resp, err := http.Get("https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/v28.0/vmm/src/api/openapi/cloud-hypervisor.yaml")
+	// TODO: Use stable release includes patch https://github.com/cloud-hypervisor/cloud-hypervisor/commit/3dd01443d51b7d669ca770ae78fd2a01e9d103b7
+	resp, err := http.Get("https://raw.githubusercontent.com/cloud-hypervisor/cloud-hypervisor/3dd01443d51b7d669ca770ae78fd2a01e9d103b7/vmm/src/api/openapi/cloud-hypervisor.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cloudhypervisor/client.go
+++ b/pkg/cloudhypervisor/client.go
@@ -750,8 +750,8 @@ type ConsoleConfig struct {
 }
 
 type CpuAffinity struct {
-	HostCpus []int `json:"host_cpus,omitempty"`
-	Vcpu     int   `json:"vcpu,omitempty"`
+	HostCpus []int `json:"host_cpus"`
+	Vcpu     int   `json:"vcpu"`
 }
 
 type CpuFeatures struct {


### PR DESCRIPTION
When the field `Vcpu` is 0, golang JSON encoder will ignore it, causing field `vcpu` missing in output file. So we should make field `Vcpu` required in `CpuAffinity`
https://github.com/smartxworks/virtink/blob/d7d5162c2d9fc3edc6ea264e58336d212d1fd752/pkg/cloudhypervisor/client.go#L752-L755

I have updated CH openapi manifest file, see [patch](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5186). Currently we can use the openapi yaml in this commit, and nothing else has be changed compared to CH release v28.0