### PR TITLE
fix: Add resource requirements for masquerade initContainers

### DIFF
--- a/pkg/controller/vm_controller.go
+++ b/pkg/controller/vm_controller.go
@@ -642,8 +642,9 @@ func (r *VMReconciler) buildVMPod(ctx context.Context, vm *virtv1alpha1.VirtualM
 
 		if iface.Masquerade != nil {
 			vmPod.Spec.InitContainers = append(vmPod.Spec.InitContainers, corev1.Container{
-				Name:  "enable-ip-forward",
-				Image: r.PrerunnerImageName,
+				Name:      "enable-ip-forward",
+				Image:     r.PrerunnerImageName,
+				Resources: vm.Spec.Resources,
 				SecurityContext: &corev1.SecurityContext{
 					Privileged: &[]bool{true}[0],
 				},


### PR DESCRIPTION
The init containers will be taken into account when determining the QoS class for the pod, without resources requirements in initContainer `enable-ip-forward`, the masquerade pod with cpuDedicatedPlacement will not work!